### PR TITLE
-feat: dockerfile 및 docker-compose.yml 추가 / next.config.ts에 standalon…

### DIFF
--- a/next-web-renewal/.idea/.gitignore
+++ b/next-web-renewal/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 디폴트 무시된 파일
+/shelf/
+/workspace.xml
+# 에디터 기반 HTTP 클라이언트 요청
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/next-web-renewal/.idea/inspectionProfiles/Project_Default.xml
+++ b/next-web-renewal/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/next-web-renewal/.idea/modules.xml
+++ b/next-web-renewal/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/next-web-renewal.iml" filepath="$PROJECT_DIR$/.idea/next-web-renewal.iml" />
+    </modules>
+  </component>
+</project>

--- a/next-web-renewal/.idea/next-web-renewal.iml
+++ b/next-web-renewal/.idea/next-web-renewal.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/next-web-renewal/.idea/vcs.xml
+++ b/next-web-renewal/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/next-web-renewal/Dockerfile
+++ b/next-web-renewal/Dockerfile
@@ -1,0 +1,43 @@
+# ----------------- STAGE 1: 빌드 환경 (Builder) -----------------
+FROM node:18-alpine AS builder
+
+# 작업 디렉토리 설정
+WORKDIR /app
+
+# 의존성 설치를 위해 package.json 관련 파일 먼저 복사
+COPY package*.json ./
+
+# 의존성 설치 (프로젝트에 맞는 명령어로 수정)
+RUN npm install
+
+# 소스코드 복사
+COPY . .
+
+# next.config.js에 output: 'standalone'이 적용된 상태로 빌드
+RUN npm run build
+
+
+# ----------------- STAGE 2: 프로덕션 환경 (Runner) -----------------
+FROM node:18-alpine
+
+# 작업 디렉토리 설정
+WORKDIR /app
+
+# 프로덕션 환경으로 설정
+ENV NODE_ENV=production
+
+# 빌드 스테이지에서 생성된 standalone 폴더 복사
+# 여기에는 최소화된 node_modules와 server.js가 포함됩니다.
+COPY --from=builder /app/.next/standalone ./
+
+# public 폴더와 .next/static 폴더 복사
+# 정적 에셋(이미지, 폰트 등)과 빌드된 CSS/JS 파일을 위함입니다.
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next/static ./.next/static
+
+# 3000번 포트 개방
+EXPOSE 3000
+
+# 컨테이너 실행 명령어
+# npm start가 아닌, standalone 폴더 안의 server.js를 직접 실행합니다.
+CMD ["node", "server.js"]

--- a/next-web-renewal/docker-compose.yml
+++ b/next-web-renewal/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+
+services:
+  next-app:
+    # Dockerfile이 있는 현재 디렉토리를 사용하여 이미지를 빌드합니다.
+    build: .
+    # 컨테이너 이름을 지정합니다.
+    container_name: next-app-container
+    # 재시작 정책: 컨테이너가 중지되면 항상 다시 시작합니다.
+    restart: always
+    # 포트 매핑: 호스트의 80번 포트 -> 컨테이너의 3000번 포트
+    ports:
+      - "80:3000"

--- a/next-web-renewal/next.config.ts
+++ b/next-web-renewal/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
+//
 const nextConfig: NextConfig = {
   /* config options here */
+    output: "standalone"
 };
 
 export default nextConfig;


### PR DESCRIPTION
- 추가된 도커파일들은 도커에 컨터이너로 해당 프로젝트를 배포하기 위한 목적으로 작성되었습니다.
- 로컬에서 테스트를 원한다면, 도커 데스크탑 앱과 도커 컴포즈를 설치한 이후에 터미널에 해당 프로젝트 위치에서 아래와 같은 커맨드를 입력하세요.

-백그라운드에서 빌드 후 실행
docker-compose up -d --build

-컨테이너 중지 및 삭제
docker-compose down

## 코파일럿 요약
This pull request introduces several configuration and setup changes to the `next-web-renewal` project, including updates to `.idea` files for project settings, Docker integration for containerized development and deployment, and adjustments to the Next.js configuration for standalone output. These changes aim to streamline development workflows and prepare the project for production deployment.

### Project configuration updates:

* [`next-web-renewal/.idea/.gitignore`](diffhunk://#diff-ead16fb1dac47afaf8c5c03813f7bb6116f225c9fd4ea1dcfb3962648b529282R1-R8): Added rules to ignore IntelliJ IDEA-specific files and directories, such as `workspace.xml`, `httpRequests`, and `dataSources`.
* [`next-web-renewal/.idea/inspectionProfiles/Project_Default.xml`](diffhunk://#diff-4664900bf894ce53ec71c3f01999ae4ba9aad2083f40f3371ad0028829d48a9fR1-R6): Enabled ESLint inspection with a warning level in the default project profile.
* [`next-web-renewal/.idea/modules.xml`](diffhunk://#diff-4c46ccc0d065609df00b55baaf67e6667f4ad98c6d20d33d0adf916f56b4fe64R1-R8): Configured the project module manager with the module file path.
* [`next-web-renewal/.idea/next-web-renewal.iml`](diffhunk://#diff-45ccf4730e62e26316de9a906dcb28fae6230b3693369052fc82f4509c02c2daR1-R12): Defined module settings, including excluded folders (`.tmp`, `temp`, `tmp`) and inherited JDK configuration.
* [`next-web-renewal/.idea/vcs.xml`](diffhunk://#diff-12fc6410c35a066acd569936d060203c3290d756d257cb10396e073b9f8ec9a9R1-R6): Set up Git as the version control system for the project directory.

### Docker integration:

* [`next-web-renewal/Dockerfile`](diffhunk://#diff-3a15ab2264febcf82996efd6c3e816e819f5b3d9fef2b3dd802602dbd007286eR1-R43): Added a multi-stage Dockerfile with a build stage for compiling the Next.js application and a production stage for running the application using a minimal setup.
* [`next-web-renewal/docker-compose.yml`](diffhunk://#diff-48ff680c136614ad602b83182ac57bd6832582e11f0c88f052fc1de63eecc8acR1-R13): Introduced a `docker-compose.yml` file to define the `next-app` service, set up port mapping (host port 80 to container port 3000), and specify a restart policy.

### Next.js configuration:

* [`next-web-renewal/next.config.ts`](diffhunk://#diff-e19fd1f3075885e87a62ae034306781c87b720c3d70a3ad7f85577f3d8e7730cR3-R6): Updated the Next.js configuration to enable standalone output for optimized production builds.